### PR TITLE
CI: Add GitHub Actions workflow for test, lint, type-check, and format

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,6 @@
+TZ=UTC
+PORT=3333
+HOST=localhost
+LOG_LEVEL=info
+APP_KEY=abcdefghijklmnop #dummy
+NODE_ENV=development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,5 @@ jobs:
       - name: Check formatting
         run: npx prettier --check .
 
-      - name: Copy environment file
-        run: cp .env.example .env
-
       - name: Run tests
         run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ['default']
   pull_request:
-    branches: ['default']
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["default"]
+    branches: ['default']
   pull_request:
-    branches: ["default"]
+    branches: ['default']
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ["default"]
+  pull_request:
+    branches: ["default"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type-check
+        run: npm run typecheck
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npx prettier --check .
+
+      - name: Copy environment file
+        run: cp .env.example .env
+
+      - name: Run tests
+        run: npm run test

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -32,7 +32,7 @@
 - A GitHub Actions workflow is now located at `.github/workflows/ci.yml`.
 - It runs on:
   - Push events to the `default` branch
-  - Pull request events targeting the `default` branch
+  - All pull request events
 - Workflow steps:
   1. Checkout repository
   2. Setup Node.js 22.x with npm cache
@@ -40,8 +40,9 @@
   4. Run type-check (`npm run typecheck`)
   5. Run lint (`npm run lint`)
   6. Check formatting (`npx prettier --check .`)
-  7. Copy `.env.example` to `.env`
-  8. Run tests (`npm run test`)
+
+  7. Run tests (`npm run test`)
+- Environment variables are loaded from `.env.test`; no manual copy of `.env` is needed.
 - Any lint or formatting violations will cause CI to fail without auto-fixing.
 
 ## Branch rules

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,9 +1,11 @@
 # Repository Summary
 
 ## Purpose
+
 **Feather Memoir** is a TypeScript AdonisJS application for archiving and processing user tweets. It supports normal tweets, retweets, and quoted tweets, storing data in a SQLite database via Lucid ORM.
 
 ## Setup
+
 - Install dependencies: `npm install`
 - Configure environment: copy `.env.example` to `.env` and adjust variables
 - Database: run migrations and seeders via `node ace migration:run` and `node ace db:seed`
@@ -16,6 +18,7 @@
   - `npm run typecheck`: run TypeScript type checking
 
 ## Structure
+
 - `bin/`: entrypoints for server (`server.ts`), console (`console.ts`), and test runner (`test.ts`)
 - `app/`: controllers, models, middleware, exceptions
 - `config/`: AdonisJS and database configuration
@@ -25,8 +28,23 @@
 - Other files: `package.json`, `tsconfig.json`, `eslint.config.js`, `adonisrc.ts`, `.env.example`
 
 ## CI & Workflows
-No GitHub workflows detected in `.github/workflows`. CI-related tasks (lint, format, typecheck, tests) are defined as npm scripts in `package.json`.
+
+- A GitHub Actions workflow is now located at `.github/workflows/ci.yml`.
+- It runs on:
+  - Push events to the `default` branch
+  - Pull request events targeting the `default` branch
+- Workflow steps:
+  1. Checkout repository
+  2. Setup Node.js 22.x with npm cache
+  3. Install dependencies (`npm ci`)
+  4. Run type-check (`npm run typecheck`)
+  5. Run lint (`npm run lint`)
+  6. Check formatting (`npx prettier --check .`)
+  7. Copy `.env.example` to `.env`
+  8. Run tests (`npm run test`)
+- Any lint or formatting violations will cause CI to fail without auto-fixing.
 
 ## Branch rules
+
 - The "master/main" branch is named `default`. Your work mostly will start from this branch unless otherwise stated, so be sure to pull all the remote changes before starting to work! Notice that this naming convention doesn't follow the today's widely-accepted git/github workflow standard.
 - The branch of your (i.e. OpenHands's) sessions should be named `openhands/<describe your work>`.

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -40,7 +40,6 @@
   4. Run type-check (`npm run typecheck`)
   5. Run lint (`npm run lint`)
   6. Check formatting (`npx prettier --check .`)
-
   7. Run tests (`npm run test`)
 - Environment variables are loaded from `.env.test`; no manual copy of `.env` is needed.
 - Any lint or formatting violations will cause CI to fail without auto-fixing.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-# Ignore GitHub workflows
-.github/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore GitHub workflows
+.github/


### PR DESCRIPTION
This PR adds a continuous integration pipeline via GitHub Actions. The workflow is defined in `.github/workflows/ci.yml` and triggers on:

- Push events to the `default` branch
- All pull request events

Jobs run on ubuntu-latest with Node.js 22.x. Steps include:

1. Checkout code
2. Setup Node.js 22.x with npm cache
3. Install dependencies (`npm ci`)
4. TypeScript type-check (`npm run typecheck`)
5. ESLint lint (`npm run lint`)
6. Prettier formatting check (`npx prettier --check .`)
7. Run Japa test suite (`npm run test`)

Environment variables are loaded from `.env.test`, so no manual copy of `.env` is needed. Lint or formatting errors will break the build without auto-fixing.