### PR TITLE
Write about v6 documentations to `.openhands/microagents/repo.md`

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-**Feather Memoir** is a TypeScript AdonisJS application for archiving and processing user tweets. It supports normal tweets, retweets, and quoted tweets, storing data in a SQLite database via Lucid ORM.
+**Feather Memoir** is a TypeScript **AdonisJS v6** application for archiving and processing user tweets. It supports normal tweets, retweets, and quoted tweets, storing data in a SQLite database via Lucid ORM.
 
 ## Setup
 
@@ -73,3 +73,7 @@ Any lint or formatting violations will cause the CI to fail.
 
 - Commit immediately whenever you make a small change. As a general rule, associate only one action (verb) with each commit.
 - A pre-commit hook will detect any linting, formatting, or type-check violations. The larger your changes become, the harder it is to fix those violations. From this perspective as well, please commit as early as possible whenever you make any changes.
+
+## AdonisJS v6
+
+Your knowledge of AdonisJS is outdated. You only know versions prior to v5, but we are using **v6** in this project. Make sure to read the latest documentation located in `/adonisjs-docs/`.


### PR DESCRIPTION
## Summary by Sourcery

Update the project repository documentation to reflect the use of AdonisJS v6 and provide a reference to the latest v6 documentation.

Documentation:
- Clarify that Feather Memoir is built on AdonisJS v6 in the purpose section
- Add a new 'AdonisJS v6' section directing users to the updated documentation at `/adonisjs-docs/`