### PR TITLE
target_users: mark flags as required

### DIFF
--- a/commands/target_users/add.ts
+++ b/commands/target_users/add.ts
@@ -8,10 +8,10 @@ export default class AddTargetUser extends BaseCommand {
     startApp: true,
   }
 
-  @flags.number({ description: 'ID of the new target user' })
+  @flags.number({ description: 'ID of the new target user', required: true })
   declare id: number
 
-  @flags.string({ description: 'Username of the new target user' })
+  @flags.string({ description: 'Username of the new target user', required: true })
   declare username: string
 
   @flags.boolean({ name: 'enabled', description: 'Whether the user is enabled', default: true })

--- a/commands/target_users/disable.ts
+++ b/commands/target_users/disable.ts
@@ -8,7 +8,7 @@ export default class DisableTargetUser extends BaseCommand {
     startApp: true,
   }
 
-  @flags.number({ description: 'ID of the target user to disable' })
+  @flags.number({ description: 'ID of the target user to disable', required: true })
   declare id: number
 
   public async run() {

--- a/commands/target_users/enable.ts
+++ b/commands/target_users/enable.ts
@@ -8,7 +8,7 @@ export default class EnableTargetUser extends BaseCommand {
     startApp: true,
   }
 
-  @flags.number({ description: 'ID of the target user to enable' })
+  @flags.number({ description: 'ID of the target user to enable', required: true })
   declare id: number
 
   public async run() {

--- a/commands/target_users/remove.ts
+++ b/commands/target_users/remove.ts
@@ -8,7 +8,7 @@ export default class RemoveTargetUser extends BaseCommand {
     startApp: true,
   }
 
-  @flags.number({ description: 'ID of the target user to remove' })
+  @flags.number({ description: 'ID of the target user to remove', required: true })
   declare id: number
 
   public async run() {


### PR DESCRIPTION
The following flags for target_users:* commands are now marked as required to prevent runtime errors when missing:

- `target_users:add`: id, username
- `target_users:disable`: id
- `target_users:enable`: id
- `target_users:remove`: id

Closes #16

## Summary by Sourcery

Mark ID and username flags as required for target_users commands to prevent runtime errors when missing.

Bug Fixes:
- Require id and username flags for target_users:add command
- Require id flag for target_users:disable command
- Require id flag for target_users:enable command
- Require id flag for target_users:remove command